### PR TITLE
Add new repository id's to make a distinction between snapshot and release repositories

### DIFF
--- a/travis_maven_settings.xml
+++ b/travis_maven_settings.xml
@@ -10,6 +10,16 @@
       <username>${env.TRAVIS_DEPLOY_USERNAME}</username>
       <password>${env.TRAVIS_DEPLOY_PASSWORD}</password>
     </server>
+    <server>
+      <id>ala-repo-release</id>
+      <username>${env.TRAVIS_DEPLOY_USERNAME}</username>
+      <password>${env.TRAVIS_DEPLOY_PASSWORD}</password>
+    </server>
+    <server>
+      <id>ala-repo-snapshot</id>
+      <username>${env.TRAVIS_DEPLOY_USERNAME}</username>
+      <password>${env.TRAVIS_DEPLOY_PASSWORD}</password>
+    </server>
 
   </servers>
 

--- a/travis_maven_settings_simple.xml
+++ b/travis_maven_settings_simple.xml
@@ -5,5 +5,15 @@
       <username>${env.TRAVIS_DEPLOY_USERNAME}</username>
       <password>${env.TRAVIS_DEPLOY_PASSWORD}</password>
     </server>
+    <server>
+      <id>ala-repo-release</id>
+      <username>${env.TRAVIS_DEPLOY_USERNAME}</username>
+      <password>${env.TRAVIS_DEPLOY_PASSWORD}</password>
+    </server>
+    <server>
+      <id>ala-repo-snapshot</id>
+      <username>${env.TRAVIS_DEPLOY_USERNAME}</username>
+      <password>${env.TRAVIS_DEPLOY_PASSWORD}</password>
+    </server>
   </servers>
 </settings>


### PR DESCRIPTION
Matching the id's to the gradle repository id's and the mirrorOf definition

Not removing the existing repository id so everything that is currently working will still work.